### PR TITLE
Review: removing record_latency references

### DIFF
--- a/model-deployment-examples/LightGBM/score.py
+++ b/model-deployment-examples/LightGBM/score.py
@@ -1,7 +1,6 @@
 import json
 import os
 from cloudpickle import cloudpickle
-from monitor import record_latency
 
 
 model_name = 'model.pkl'
@@ -29,7 +28,6 @@ def load_model(model_file_name=model_name):
         raise Exception('{0} is not found in model directory {1}'.format(model_file_name, model_dir))
 
 
-@record_latency(name='LightGBM Model')
 def predict(data, model=load_model()):
     """
     Returns prediction given the model and data to predict

--- a/model-deployment-examples/LightGBM_ONNX/score.py
+++ b/model-deployment-examples/LightGBM_ONNX/score.py
@@ -4,7 +4,6 @@ import onnxruntime as rt
 import os
 import pandas as pd
 from sklearn.preprocessing import LabelEncoder
-from monitor import record_latency
 
 
 model_name = 'model.onnx'
@@ -32,7 +31,6 @@ def load_model(model_file_name=model_name):
         raise Exception('{0} is not found in model directory {1}'.format(model_file_name, model_dir))
 
 
-@record_latency(name='LightGBM Model ONNX')
 def predict(data, model=load_model()):
     """
     Returns prediction given the model and data to predict

--- a/model-deployment-examples/NLP_TF/score.py
+++ b/model-deployment-examples/NLP_TF/score.py
@@ -7,8 +7,6 @@ import tensorflow as tf
 
 from transformers import GPT2Tokenizer, TFGPT2Model
 
-from monitor import record_latency
-
 
 model_name = 'tf_model'
 tokenize_name = 'vocab'
@@ -31,7 +29,6 @@ def load_model(model_file_name=model_name):
         raise FileNotFoundError(f'{model_file_name} is not found in model directory {model_dir}.')
 
 
-@record_latency(name='TF NLP')
 def predict(data, model=load_model()):
     """
     Returns prediction given the model and data to predict

--- a/model-deployment-examples/PyTorch_ResNet152/score.py
+++ b/model-deployment-examples/PyTorch_ResNet152/score.py
@@ -8,7 +8,6 @@ from PIL import Image
 import base64
 import tempfile
 
-from monitor import record_latency
 
 Image.MAX_IMAGE_PIXELS = None
 
@@ -234,7 +233,6 @@ def load_model(model_file_name=model_name):
         raise FileNotFoundError(f'{model_file_name} is not found in model directory {model_dir}.')
 
 
-@record_latency(name='PyTorch ResNet152')
 def predict(data, model=load_model()):
     """
     Returns prediction given the model and data to predict

--- a/model-deployment-examples/RandomForest/score.py
+++ b/model-deployment-examples/RandomForest/score.py
@@ -2,8 +2,6 @@ import json
 import os
 from cloudpickle import cloudpickle
 
-from monitor import record_latency
-
 
 model_name = 'model.pkl'
 
@@ -30,7 +28,6 @@ def load_model(model_file_name=model_name):
         raise Exception('{0} is not found in model directory {1}'.format(model_file_name, model_dir))
 
 
-@record_latency(name='Random Forest')
 def predict(data, model=load_model()):
     """
     Returns prediction given the model and data to predict

--- a/model-deployment-examples/SklearnLR/score.py
+++ b/model-deployment-examples/SklearnLR/score.py
@@ -2,8 +2,6 @@ import json
 import os
 from cloudpickle import cloudpickle
 
-from monitor import record_latency
-
 
 model_name = 'model.pkl'
 
@@ -30,7 +28,6 @@ def load_model(model_file_name=model_name):
         raise Exception('{0} is not found in model directory {1}'.format(model_file_name, model_dir))
 
 
-@record_latency(name='Sklearn Linear Regression')
 def predict(data, model=load_model()):
     """
     Returns prediction given the model and data to predict

--- a/model-deployment-examples/TFKeras/score.py
+++ b/model-deployment-examples/TFKeras/score.py
@@ -4,7 +4,6 @@ import tensorflow as tf
 import tensorflow.keras as keras
 import numpy as np
 from tensorflow.keras.models import load_model as klm
-from monitor import record_latency
 
  
 # Insert the name of your model here.
@@ -27,7 +26,6 @@ def load_model(model_file_name=model_name):
         raise FileNotFoundError(f'{model_file_name} is not found in model directory {model_dir}.')
  
 
-@record_latency(name='TF Keras') 
 def predict(data, model=load_model()):
     """
     Returns prediction given the model and data to predict

--- a/model-deployment-examples/TF_ResNet152/score.py
+++ b/model-deployment-examples/TF_ResNet152/score.py
@@ -7,7 +7,6 @@ from tempfile import TemporaryDirectory
 import base64
 from PIL import Image
 import io
-from monitor import record_latency
 
 Image.MAX_IMAGE_PIXELS = None
 
@@ -34,7 +33,6 @@ def load_model(model_file_name=model_name):
         raise FileNotFoundError(f'{model_file_name} is not found in model directory {model_dir}.')
 
 
-@record_latency(name='Tensorflow ResNet152')
 def predict(data, model=load_model()):
     """
     Returns prediction given the model and data to predict

--- a/model-deployment-examples/XGBoost/score.py
+++ b/model-deployment-examples/XGBoost/score.py
@@ -2,7 +2,6 @@ import json
 import os
 from cloudpickle import cloudpickle
 import pandas as pd
-from monitor import record_latency
 
 
 model_name = 'model.pkl'
@@ -30,7 +29,6 @@ def load_model(model_file_name=model_name):
         raise Exception('{0} is not found in model directory {1}'.format(model_file_name, model_dir))
 
 
-@record_latency(name='XGBoost Model')
 def predict(data, model=load_model()):
     """
     Returns prediction given the model and data to predict

--- a/model-deployment-examples/XGBoost_ONNX/score.py
+++ b/model-deployment-examples/XGBoost_ONNX/score.py
@@ -7,9 +7,6 @@ os.environ["GIT_PYTHON_REFRESH"] = "quiet"
 import pandas as pd
 from sklearn.preprocessing import LabelEncoder
 
-from monitor import record_latency
-
-
 
 model_name = 'model.onnx'
 transformer_name = 'onnx_data_transformer.json'
@@ -36,7 +33,6 @@ def load_model(model_file_name=model_name):
         raise Exception('{0} is not found in model directory {1}'.format(model_file_name, model_dir))
 
 
-@record_latency(name='XGBoost Model ONNX')
 def predict(data, model=load_model()):
     """
     Returns prediction given the model and data to predict


### PR DESCRIPTION
record_latency comes from here https://bitbucket.oci.oraclecorp.com/projects/ODSC/repos/model_deployment_testing/browse/deployment_testing/deploy_test/monitor.py#45 

I can copy this file over and it’s dependencies, but since it’s just for timing maybe better I just take it the reference to it all together. Making a new PR for that now