### PR TITLE
Parquet example

### DIFF
--- a/data-wrangling/parquet-from-oss.ipynb
+++ b/data-wrangling/parquet-from-oss.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "aa2046de",
+   "id": "0da99b91",
    "metadata": {},
    "source": [
     "## Reading/Writing Parquet Files From/to OCI Object Storage with Pandas\n",
@@ -19,7 +19,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7b6c2fbc",
+   "id": "22dc245b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -29,7 +29,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "202379bb",
+   "id": "bd62ebae",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -47,7 +47,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55e50263",
+   "id": "ba1c87b3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,7 +59,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6ab82d93",
+   "id": "5f68024c",
    "metadata": {},
    "source": [
     "# Single Large File"
@@ -68,7 +68,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10759d13",
+   "id": "2a2d5c4a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -79,10 +79,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f0fdfa93",
+   "id": "a1b0b709",
    "metadata": {},
    "outputs": [],
    "source": [
+    "# using the `pyarrow` engine. You can also use `fastparquet`. \n",
     "for f in large_files: \n",
     "    df = pd.read_parquet(f\"oci://{bucket}@{namespace}/{f}\", \n",
     "                     storage_options=default_signer(),\n",
@@ -94,7 +95,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1d1c2c0c",
+   "id": "06706b05",
    "metadata": {},
    "source": [
     "# Multiple Large Files"
@@ -103,7 +104,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51fade09",
+   "id": "c2d202b5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,7 +114,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "efb5f2d4",
+   "id": "8436ded0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -124,7 +125,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d904ade7",
+   "id": "0e146024",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -135,7 +136,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d3c597c4",
+   "id": "22421b16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -148,7 +149,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cf98a539",
+   "id": "a27c6c4b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -158,7 +159,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "352c80fe",
+   "id": "6a52a973",
    "metadata": {},
    "source": [
     "## Write Parquet Files to Object Storage: "
@@ -167,7 +168,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "795d3503",
+   "id": "f4923c6b",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/data-wrangling/parquet-from-oss.ipynb
+++ b/data-wrangling/parquet-from-oss.ipynb
@@ -1,0 +1,208 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "aa2046de",
+   "metadata": {},
+   "source": [
+    "## Reading/Writing Parquet Files From/to OCI Object Storage with Pandas\n",
+    "\n",
+    "The setup for this notebook is simple. I used the `generalml_p37_cpu_v1` conda environment. This environment has ADS,pyarrow, pandas, snappy, and fastparquet pre-installed. \n",
+    "\n",
+    "I also upgraded the version of ADS. In this notebook ADS version 2.5.8 was used. \n",
+    "\n",
+    "To read/write files to Object Storage, use `ocifs` : \n",
+    "* github.com/oracle/ocifs\n",
+    "* docs: https://docs.oracle.com/en-us/iaas/tools/ocifs-sdk/latest/unix-operations.html "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7b6c2fbc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#!pip install oracle-ads --upgrade"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "202379bb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ads \n",
+    "from ads.common.auth import default_signer\n",
+    "import pandas as pd \n",
+    "import fsspec\n",
+    "from ocifs import OCIFileSystem\n",
+    "\n",
+    "# Using resource principal auth method: \n",
+    "print(ads.__version__)\n",
+    "ads.set_auth(auth=\"resource_principal\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "55e50263",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# object storage bucket + data \n",
+    "# this bucket is publicly available \n",
+    "bucket = \"hosted-ds-datasets\"\n",
+    "namespace = \"bigdatadatasciencelarge\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6ab82d93",
+   "metadata": {},
+   "source": [
+    "# Single Large File"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10759d13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ~ 440 MB, 14M rows. \n",
+    "large_files = [\"nyc_tlc/2009/01/data.parquet\"] # NYC Taxi dataset "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f0fdfa93",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for f in large_files: \n",
+    "    df = pd.read_parquet(f\"oci://{bucket}@{namespace}/{f}\", \n",
+    "                     storage_options=default_signer(),\n",
+    "                     engine=\"pyarrow\")\n",
+    "    print(f\"file {f}\")\n",
+    "    print(df.head())\n",
+    "    print(f\"size {df.shape}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d1c2c0c",
+   "metadata": {},
+   "source": [
+    "# Multiple Large Files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "51fade09",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from oci.auth.signers import get_resource_principals_signer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "efb5f2d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Using resource principal for authn. \n",
+    "fs = OCIFileSystem(signer=get_resource_principals_signer())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d904ade7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This is a small sample of the overall NYC Taxi dataset. There are 4 files in total, each of size ~ 450MB. \n",
+    "relevant_files = fs.ls(f\"{bucket}@{namespace}/nyc_tlc/2009/\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d3c597c4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time \n",
+    "# this operation takes about 50 secs: \n",
+    "df = pd.concat((pd.read_parquet(f\"oci://{f}/data.parquet\", storage_options=default_signer(), engine=\"pyarrow\") for f in relevant_files), \n",
+    "               ignore_index=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cf98a539",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ~ 56M rows \n",
+    "df.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "352c80fe",
+   "metadata": {},
+   "source": [
+    "## Write Parquet Files to Object Storage: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "795d3503",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time \n",
+    "\n",
+    "# Writing the dataframe as a parquet file to Object Storage. \n",
+    "# Insert the name of your bucket and namespace you want to write parquet. \n",
+    "# this operation takes about 2 mins\n",
+    "your_bucket = \"\"\n",
+    "your_namespace = \"\"\n",
+    "\n",
+    "df.to_parquet(f\"oci://{your_bucket}@{your_namespace}/taxi-data.parquet\", \n",
+    "                     storage_options=default_signer())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:generalml_p37_cpu_v1]",
+   "language": "python",
+   "name": "conda-env-generalml_p37_cpu_v1-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Simple notebook to read public datasets from object storage. Files are written in parquet. One or more larger files (400+ MB per file). 

Using pandas and ocifs. pyarrow is the backend engine. 